### PR TITLE
Fixes `Cannot redefine property: promise` error.

### DIFF
--- a/lib/songbird.js
+++ b/lib/songbird.js
@@ -54,6 +54,9 @@
 
   definePromiseProperty = function(target, factory) {
     var cacheKey;
+    if (target.hasOwnProperty("promise")) {
+      return;
+    }
     cacheKey = "__songbird__";
     return Object.defineProperty(target, "promise", {
       enumerable: false,

--- a/src/songbird.coffee
+++ b/src/songbird.coffee
@@ -42,6 +42,8 @@ proxyBuilder = (that) ->
   result
 
 definePromiseProperty = (target, factory) ->
+  return if target.hasOwnProperty "promise"
+
   cacheKey = "__songbird__"
   Object.defineProperty target, "promise",
     enumerable: false


### PR DESCRIPTION
Modules that are linked in during development end up having multiple instance of `songbird` required and they all try to define `promise`. This patch fixes that.

```
/app/node_modules/songbird/lib/songbird.js:59
    return Object.defineProperty(target, "promise", {
                  ^
TypeError: Cannot redefine property: promise
  at Function.defineProperty (native)
  at definePromiseProperty (/app/node_modules/songbird/lib/songbird.js:59:19)
  at Object.<anonymous> (/app/node_modules/songbird/lib/songbird.js:87:5)
  at Object.<anonymous> (/app/node_modules/songbird/lib/songbird.js:90:4)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
...
```
